### PR TITLE
Merge fix of PingTtpsFromDic1ExampleStarter builds an invalid Task — missing required coding.version on target-endpoints input

### DIFF
--- a/src/test/java/dev/dsf/bpe/start/PingTtpsFromDic1ExampleStarter.java
+++ b/src/test/java/dev/dsf/bpe/start/PingTtpsFromDic1ExampleStarter.java
@@ -46,8 +46,7 @@ public class PingTtpsFromDic1ExampleStarter
 				"OrganizationAffiliation?primary-organization:identifier=http://dsf.dev/sid/organization-identifier|highmed.org"
 						+ "&role=http://dsf.dev/fhir/CodeSystem/organization-role|TTP"
 						+ "&_include=OrganizationAffiliation:endpoint"))
-				.getType().addCoding().setSystem(CodeSystem.DsfPing.URL)
-				.setCode(CodeSystem.DsfPing.Code.TARGET_ENDPOINTS.getValue());
+				.getType().addCoding(CodeSystem.DsfPing.fromCode(CodeSystem.DsfPing.Code.TARGET_ENDPOINTS));
 
 		return task;
 	}


### PR DESCRIPTION
PingTtpsFromDic1ExampleStarter.java (in src/test/java/dev/dsf/bpe/start/) builds the target-endpoints input Coding by hand instead of using the existing CodeSystem.DsfPing.fromCode() helper, and leaves out the version field. The dsf-task-start-ping FHIR profile that this project ships requires that field (min value="1" on Task.input:target-endpoints.type.coding.version, see [dsf-task-start-ping.xml:84-89](vscode-webview://1f3lb3ot12233gk56cfelrne31bl2ke5bc78i4f1c42g2d8de5ur/src/main/resources/fhir/StructureDefinition/dsf-task-start-ping.xml#L84-L89)), so any Task built by this example is rejected by profile validation.